### PR TITLE
Add sample output like furik

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"log"
 	"os"
@@ -8,6 +10,7 @@ import (
 
 	"github.com/urfave/cli"
 	"github.com/yhkaplan/gull/date"
+	"github.com/yhkaplan/gull/github"
 )
 
 func main() {
@@ -53,6 +56,63 @@ func main() {
 				to = date.EndOfDay(to)
 
 				fmt.Printf("Show activities: from %v, to %v\n", from, to)
+
+				// TODO
+				// Sample
+				client, err := github.NewClient("giraffate", os.Getenv("GITHUB_TOKEN"))
+				if err != nil {
+					return err
+				}
+
+				events, err := client.GetEventsWithGrouping(context.Background(), from, to)
+				if err != nil {
+					return err
+				}
+				for _, event := range events {
+					var (
+						eventType, title, link string
+					)
+
+					title = *event.Type     // TODO
+					eventType = *event.Type // TODO
+					switch title {
+					case "IssuesEvent":
+						issuesEvent, err := github.GetIssuesEventFromRaw(event)
+						if err != nil {
+							return err
+						}
+						link = *issuesEvent.Issue.HTMLURL
+					case "PullRequestEvent":
+						pullRequestEvent, err := github.GetPullRequestEventFromRaw(event)
+						if err != nil {
+							return err
+						}
+						link = *pullRequestEvent.PullRequest.HTMLURL
+					case "PullRequestReviewCommentEvent":
+						pullRequestReviewCommentEvent, err := github.GetPullRequestReviewCommentEventFromRaw(event)
+						if err != nil {
+							return err
+						}
+						link = *pullRequestReviewCommentEvent.Comment.HTMLURL
+					case "IssueCommentEvent":
+						issueCommentEvent, err := github.GetIssueCommentEventFromRaw(event)
+						if err != nil {
+							return err
+						}
+						link = *issueCommentEvent.Comment.HTMLURL
+					case "CommitCommentEvent":
+						commitCommentEvent, err := github.GetCommitCommentEventFromRaw(event)
+						if err != nil {
+							return err
+						}
+						link = *commitCommentEvent.Comment.HTMLURL
+					default:
+						return errors.New("invalid event type")
+					}
+
+					fmt.Printf("- [%s](%s: %s)\n", eventType, link, title)
+				}
+
 				return nil
 			},
 		},

--- a/main.go
+++ b/main.go
@@ -73,44 +73,48 @@ func main() {
 						eventType, title, link string
 					)
 
-					title = *event.Type     // TODO
-					eventType = *event.Type // TODO
-					switch title {
+					eventType = *event.Type
+					switch eventType {
 					case "IssuesEvent":
 						issuesEvent, err := github.GetIssuesEventFromRaw(event)
 						if err != nil {
 							return err
 						}
 						link = *issuesEvent.Issue.HTMLURL
+						title = *issuesEvent.Issue.Title
 					case "PullRequestEvent":
 						pullRequestEvent, err := github.GetPullRequestEventFromRaw(event)
 						if err != nil {
 							return err
 						}
 						link = *pullRequestEvent.PullRequest.HTMLURL
+						title = *pullRequestEvent.PullRequest.Title
 					case "PullRequestReviewCommentEvent":
 						pullRequestReviewCommentEvent, err := github.GetPullRequestReviewCommentEventFromRaw(event)
 						if err != nil {
 							return err
 						}
 						link = *pullRequestReviewCommentEvent.Comment.HTMLURL
+						title = *pullRequestReviewCommentEvent.PullRequest.Title + " (comment)"
 					case "IssueCommentEvent":
 						issueCommentEvent, err := github.GetIssueCommentEventFromRaw(event)
 						if err != nil {
 							return err
 						}
 						link = *issueCommentEvent.Comment.HTMLURL
+						title = *issueCommentEvent.Issue.Title + " (comment)"
 					case "CommitCommentEvent":
 						commitCommentEvent, err := github.GetCommitCommentEventFromRaw(event)
 						if err != nil {
 							return err
 						}
 						link = *commitCommentEvent.Comment.HTMLURL
+						title = *commitCommentEvent.Repo.HTMLURL + " (comment)"
 					default:
 						return errors.New("invalid event type")
 					}
 
-					fmt.Printf("- [%s](%s: %s)\n", eventType, link, title)
+					fmt.Printf("- [%s](%s): %s\n", title, link, eventType)
 				}
 
 				return nil

--- a/main.go
+++ b/main.go
@@ -57,8 +57,6 @@ func main() {
 
 				fmt.Printf("Show activities: from %v, to %v\n", from, to)
 
-				// TODO
-				// Sample
 				client, err := github.NewClient(c.String("user"), os.Getenv("GITHUB_TOKEN"))
 				if err != nil {
 					return err
@@ -69,9 +67,7 @@ func main() {
 					return err
 				}
 				for _, event := range events {
-					var (
-						eventType, title, link string
-					)
+					var eventType, title, link string
 
 					eventType = *event.Type
 					switch eventType {

--- a/main.go
+++ b/main.go
@@ -59,7 +59,7 @@ func main() {
 
 				// TODO
 				// Sample
-				client, err := github.NewClient("giraffate", os.Getenv("GITHUB_TOKEN"))
+				client, err := github.NewClient(c.String("user"), os.Getenv("GITHUB_TOKEN"))
 				if err != nil {
 					return err
 				}


### PR DESCRIPTION
- furikライクにメッセージ出力するためのサンプル実装を書きました。
  - title, eventTypeは適当なメッセージを一旦出力しています。
  - サンプル実装なのでハードコーディングしてるところもあります。

```
➜  gull git:(show_message_like_furik) ✗ GITHUB_TOKEN=xxxxx go run *.go activity
Show activities: from 2018-09-20 00:00:00 +0900 JST, to 2018-09-27 23:59:59.999999999 +0900 JST
- [PullRequestEvent](https://github.com/yhkaplan/gull/pull/9: PullRequestEvent)
- [PullRequestReviewCommentEvent](https://github.com/yhkaplan/gull/pull/11#discussion_r220885299: PullRequestReviewCommentEvent)
- [PullRequestReviewCommentEvent](https://github.com/yhkaplan/gull/pull/11#discussion_r220883539: PullRequestReviewCommentEvent)
- [PullRequestEvent](https://github.com/yhkaplan/gull/pull/9: PullRequestEvent)
- [PullRequestEvent](https://github.com/yhkaplan/gull/pull/7: PullRequestEvent)
- [PullRequestReviewCommentEvent](https://github.com/yhkaplan/gull/pull/7#discussion_r220824623: PullRequestReviewCommentEvent)
- [PullRequestReviewCommentEvent](https://github.com/yhkaplan/gull/pull/7#discussion_r220819384: PullRequestReviewCommentEvent)
- [PullRequestReviewCommentEvent](https://github.com/yhkaplan/gull/pull/7#discussion_r220817903: PullRequestReviewCommentEvent)
- [PullRequestEvent](https://github.com/yhkaplan/gull/pull/7: PullRequestEvent)
- [PullRequestEvent](https://github.com/yhkaplan/gull/pull/3: PullRequestEvent)
- [PullRequestEvent](https://github.com/yhkaplan/gull/pull/3: PullRequestEvent)
```