### PR TITLE
Get my username if owner is empty

### DIFF
--- a/main.go
+++ b/main.go
@@ -36,6 +36,10 @@ func main() {
 					Value: today,
 					Usage: "To `date`",
 				},
+				cli.StringFlag{
+					Name:  "user, u",
+					Usage: "Get activities of specified `username`",
+				},
 			},
 			Action: func(c *cli.Context) error {
 				from, err := date.Parse(c.String("from"))
@@ -65,6 +69,10 @@ func main() {
 					Name:  "to, t",
 					Value: today,
 					Usage: "To `date`",
+				},
+				cli.StringFlag{
+					Name:  "user, u",
+					Usage: "Get activities of specified `username`",
 				},
 			},
 			Action: func(c *cli.Context) error {


### PR DESCRIPTION
特にオプションで指定されていない場合は、自動で（トークンを発行した）自分自身のイベントを取得したいですが、イベントリストを取得するのには必ずユーザー名が必要、という問題があります。
なのでownerは空文字を許容し、空文字の場合はAPIリクエストしてユーザー名を取得するようにします。

また、取得するユーザーを指定するために`--user`オプションを追加しました。`--user`オプションが指定されていないときは空文字になり、ユーザー名の自動取得が働く、という感じです。