### PR TITLE
Use in GHE

### DIFF
--- a/main.go
+++ b/main.go
@@ -13,6 +13,13 @@ import (
 	"github.com/yhkaplan/gull/github"
 )
 
+const (
+	defaultBaseURL = "https://api.github.com/"
+
+	envGitHubToken = "GITHUB_TOKEN"
+	envGitHubAPI   = "GITHUB_API"
+)
+
 func main() {
 	app := cli.NewApp()
 	app.Name = "gull"
@@ -57,7 +64,11 @@ func main() {
 
 				fmt.Printf("Show activities: from %v, to %v\n", from, to)
 
-				client, err := github.NewClient(c.String("user"), os.Getenv("GITHUB_TOKEN"))
+				baseURLStr := defaultBaseURL
+				if urlStr := os.Getenv(envGitHubAPI); urlStr != "" {
+					baseURLStr = urlStr
+				}
+				client, err := github.NewClient(c.String("user"), os.Getenv(envGitHubToken), baseURLStr)
 				if err != nil {
 					return err
 				}


### PR DESCRIPTION
- GHE対応！
  - 環境変数`GITHUB_API`にGHEのAPIのURLを設定することでGHEに対しても使用できます
```
GITHUB_TOKEN=xxxxx GITHUB_API='https://hostname/api/v3/' go run *.go activity --user giraffate
```